### PR TITLE
Fix attributes.ldif import failure

### DIFF
--- a/templates/attributes.ldif
+++ b/templates/attributes.ldif
@@ -953,7 +953,6 @@ objectClass: top
 objectClass: gluuAttribute
 gluuLdapAttributeName: eduPersonNickName
 gluuAttributeName: eduPersonNickName
-
 displayName: eduPersonNickName
 gluuAttributeOrigin: eduPerson
 gluuAttributePrivacyLevel: level3


### PR DESCRIPTION
Fixes this failure:

```
$ bin/ldapmodify -D "cn=directory manager" -w REDACTED -a -p 1389 -f /data/opendj/ldif/attributes.ldif 
...snip...
Error at or near line 957 in LDIF file /data/opendj/ldif/attributes.ldif:
org.opends.server.util.LDIFException: Unable to parse LDIF entry starting at
line 957 because the first line does not contain a DN (the first line was
"displayName: eduPersonNickName"
```
