### PR TITLE
Fix invalid hostname property in sample file

### DIFF
--- a/setup.properties.sample
+++ b/setup.properties.sample
@@ -24,7 +24,7 @@
 ip=
 
 ### The hostname of the server
-hostName=
+hostname=
 
 ### This information is needed for self signed certificate
 orgName=


### PR DESCRIPTION
The sample file has a typo. Pretty basic.
