### PR TITLE
Configure oxTrustLdap template to render correct hostname

### DIFF
--- a/templates/oxTrustLdap.properties
+++ b/templates/oxTrustLdap.properties
@@ -1,6 +1,6 @@
 bindDN: %(ldap_binddn)s
 bindPassword: %(encoded_ox_ldap_pw)s
-servers: localhost:1636
+servers: %(hostname)s:1636
 useSSL: true
 maxconnections: 3
 


### PR DESCRIPTION
currently oxTrustLdap.properties is hard-coded to localhost, rather than using the same hostname configuration used by oxauth-ldap.properties
