### PR TITLE
remove hardcoded paths in gen_cert.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,6 +123,7 @@ class Setup(object):
         self.oxEncodePWCommand = '%s/bin/encode.py' % self.gluuHome
         self.keytoolCommand = '/usr/java/latest/bin/keytool'
         self.opensslCommand = '/usr/bin/openssl'
+        self.defaultTrustStore = '/usr/java/latest/lib/security/'
         self.defaultTrustStoreFN = '/usr/java/latest/lib/security/cacerts'
         self.defaultTrustStorePW = 'changeit'
 
@@ -444,7 +445,7 @@ class Setup(object):
 
     def gen_openid_keys(self):
         self.logIt("Generating oxAuth OpenID Connect keys")
-        self.copyFile("static/oxauth/java.security", "/usr/java/latest/lib/security")
+        self.copyFile("static/oxauth/java.security", self.defaultTrustStore)
         self.copyFile("static/oxauth/lib/oxauth.jar", self.tomcat_user_home_lib)
         self.copyFile("static/oxauth/lib/jettison-1.3.jar", self.tomcat_user_home_lib)
         self.copyFile("static/oxauth/lib/oxauth-model.jar", self.tomcat_user_home_lib)


### PR DESCRIPTION
This is a step towards platform agnostic config.

Specifically, self.defaultTrustStoreFN and self.keytoolCommand.  Also reformat to:

flag,
flag, arg,

syntax with single quotes.
