### PR TITLE
cherry pick only opendj_index.json

### DIFF
--- a/static/opendj/opendj_index.json
+++ b/static/opendj/opendj_index.json
@@ -41,11 +41,12 @@
 		"backend": ["userRoot"]
 	},
 
-    {
-        "attribute": "oxSectorIdentifierURI",
-        "type": "string",
-        "index": ["equality"]
-    },
+    	{
+        	"attribute": "oxSectorIdentifierURI",
+	        "type": "string",
+        	"index": ["equality"],
+		"backend": ["userRoot"]
+	},
 
 	{
 		"attribute": "gluuStatus",


### PR DESCRIPTION
While working on an "single user" setup to allow installation on our gentoo environment with multiple websites and vhosts. The creation of this index failed. I've added the backend and now it creates the index alright.