### PR TITLE
Openssl compat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1227,14 +1227,7 @@ class Setup(object):
 
         # Get city and state|province code
         self.city = self.getPrompt("Enter your city or locality")
-        long_enough = False
-        while not long_enough:
-            state = self.getPrompt("Enter your state or province two letter code")
-            if len(state) != 2:
-                print "State or province code must be two characters"
-            else:
-                self.state = state
-                long_enough = True
+        self.state = self.getPrompt("Enter your state or province two letter code")
 
         # Get the Country Code
         long_enough = False

--- a/setup.py
+++ b/setup.py
@@ -704,7 +704,7 @@ class Setup(object):
                   '-out',
                   csr,
                   '-subj',
-                  '/CN=%s/O=%s/C=%s/ST=%s/L=%s' % (self.hostname, self.orgName, self.countryCode, self.state, self.city)
+                  '/C=%s/ST=%s/L=%s/O=%s/CN=%s/emailAddress=%s' % (self.countryCode, self.state, self.city, self.orgName, self.hostname, self.admin_email)
         ])
         self.run([self.opensslCommand,
                   'x509',


### PR DESCRIPTION
This pull request modifies setup.py for better openssl compatibility.

1. OpenSSL itself does not enforce 2-letter state / provinces, and this is not applicable outside the US. The length check for the state was removed.
2. The subject name produced in the self-signed certificate was rearranged to be in 'Reverse RDN order' according to RFC4514. If the subject name is not in this order, openssl may not be able to find the self-signed certificates in the trust chain in Linux, even if they were already installed using update-ca-certificates (debian) or update-ca-trust (red hat)