### PR TITLE
Do not set the opiframe cookie as HttpOnly so that scripts can access it

### DIFF
--- a/templates/https_gluu.conf
+++ b/templates/https_gluu.conf
@@ -16,7 +16,7 @@
         SSLCertificateFile %(httpdCertFn)s
         SSLCertificateKeyFile %(httpdKeyFn)s
 
-        Header edit Set-Cookie ^(.*)$ $1;HttpOnly
+        Header edit Set-Cookie ^((?!opbs).*)$ $1;HttpOnly
         SetEnvIf User-Agent ".*MSIE.*" \
                  nokeepalive ssl-unclean-shutdown \
                  downgrade-1.0 force-response-1.0


### PR DESCRIPTION
In reference to: https://support.gluu.org/integrations/opiframe-javascript-produces-unverifiable-session_state-2419#at8012

In OpenID Connect Session Management (https://openid.net/specs/openid-connect-session-1_0.html#OPiframe), the OP provides a check session URL that presents a javascript that listens for login session state changes. In oxAuth, the opiframe performs session state changes by comparing the RP's session_state with the server-side session state set by the "opbs" cookie. The check session iframe attempts to retrieve the contents of the opbs cookie using javascript, however, it cannot access the cookie due to it being set HttpOnly in the Gluu apache server.

This pull request updates the apache configuration so that the opbs cookie is NOT set to HttpOnly and so can be reached by the javascript in the check session iframe. All other cookies set by Gluu remain HttpOnly.