### PR TITLE
Don't raise exceptions if openLdap dist not exists

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2281,7 +2281,7 @@ class Setup(object):
                 packageName = "%s/%s" % ( openLdapDistFolder, file )
 
         if packageName == None:
-            raise Exception('Failed to find OpenLDAP package in folder %s !' % directory)
+            self.logIt('Failed to find OpenLDAP package in folder %s !' % directory, True)
 
         self.logIt("Found package '%s' for install" % packageName)
         if packageRpm:

--- a/setup.py
+++ b/setup.py
@@ -2282,6 +2282,7 @@ class Setup(object):
 
         if packageName == None:
             self.logIt('Failed to find OpenLDAP package in folder %s !' % openLdapDistFolder)
+	    return
 
         self.logIt("Found package '%s' for install" % packageName)
         if packageRpm:

--- a/setup.py
+++ b/setup.py
@@ -2281,7 +2281,7 @@ class Setup(object):
                 packageName = "%s/%s" % ( openLdapDistFolder, file )
 
         if packageName == None:
-            self.logIt('Failed to find OpenLDAP package in folder %s !' % directory, True)
+            self.logIt('Failed to find OpenLDAP package in folder %s !' % openLdapDistFolder)
 
         self.logIt("Found package '%s' for install" % packageName)
         if packageRpm:


### PR DESCRIPTION
This PR prevents setup process break if OpenLdap dist file is not present during setup process.  
Notice that this is the only case in setup script that `raises` an error. all other functions kindly use `logIt` and allow setup process to continue.  
Also there is a typo in log and `directory` should be changed to `openLdapDistFolder` 
This will help a lot in conditions that package is already installed on system  :)