### PR TITLE
allow change ldap_hostname

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1184,7 +1184,7 @@ class Setup(object):
             self.gen_cert('idp-encryption', self.shibJksPass, 'jetty')
             self.gen_cert('idp-signing', self.shibJksPass, 'jetty')
             self.gen_cert('asimba', self.asimbaJksPass, 'jetty')
-            self.gen_cert('openldap', self.openldapKeyPass, 'ldap', "localhost")
+            self.gen_cert('openldap', self.openldapKeyPass, 'ldap', self.ldap_hostname)
             # Shibboleth IDP and Asimba will be added soon...
             self.gen_keystore('shibIDP',
                               self.shibJksFn,

--- a/templates/oxtrust-config.json
+++ b/templates/oxtrust-config.json
@@ -73,7 +73,7 @@
     "idpBindDn":"cn=Directory Manager",
     "idpBindPassword":"%(encoded_ox_ldap_pw)s",
     "idpLdapProtocol":"ldaps",
-    "idpLdapServer":"localhost:1636",
+    "idpLdapServer":"%(ldap_hostname)s:%(ldaps_port)s",
     "idpUserFields":"",
 
     "ldifStore":"/var/ox/identity/removed",


### PR DESCRIPTION
During initial setup `ldap_hostname` is always set to `localhost` thus we cannot login after unless manually edit this from ldap server configurations.
This PR honers  `ldap_hostname` & `ldaps_port` configuration variables to fix that.
Also please note that default value for `ldap_hostname` is `localhost` so this is a non-breaking enhancement :)