### PR TITLE
oxAuth #543

### DIFF
--- a/templates/https_gluu.conf
+++ b/templates/https_gluu.conf
@@ -17,7 +17,7 @@
         SSLCertificateKeyFile %(httpdKeyFn)s
         
         # Security headers
-        Header always append X-Frame-Options SAMEORIGIN
+#        Header always append X-Frame-Options SAMEORIGIN
         Header always set X-Xss-Protection "1; mode=block"
         Header always set X-Content-Type-Options nosniff
 #        Header always set Content-Security-Policy "default-src 'self' 'unsafe-inline' https://%(hostname)s"
@@ -59,7 +59,7 @@
         <Location /oxauth>
                 ProxyPass http://localhost:8081/oxauth retry=5 disablereuse=On
                 ProxyPassReverse http://localhost:8081/oxauth
-                Header set Access-Control-Allow-Origin "*"
+#                Header set Access-Control-Allow-Origin "*"
                 Order allow,deny
                 Allow from all
         </Location>


### PR DESCRIPTION
"X-Frame-Options" header set by Apache prevents opiframe from being used by RP

oxAuth #541
CORS filter doesn't seem to process pre-flight requests in CE 3.0.x