### PR TITLE
oxAuth #700

### DIFF
--- a/templates/oxauth-config.json
+++ b/templates/oxauth-config.json
@@ -267,5 +267,6 @@
         "customParam1",
         "customParam2",
         "customParam3"
-    ]
+    ],
+    "legacyDynamicRegistrationScopeParam": false
 }


### PR DESCRIPTION
Invalid "scopes" field in Dynamic Client Registration request and response