### PR TITLE
The ldap_type variable not have the self

### DIFF
--- a/static/scripts/change_hostname/change_gluu_host.py
+++ b/static/scripts/change_hostname/change_gluu_host.py
@@ -159,7 +159,7 @@ class ChangeGluuHostname:
             ldap_server = self.server
 
         ldap_bind_dn = "cn=directory manager"
-        if ldap_type == 'openldap':
+        if self.ldap_type == 'openldap':
             ldap_bind_dn += ' ,o=gluu'
 
         ldap_server = Server("ldaps://{}:1636".format(self.server), use_ssl=True)


### PR DESCRIPTION
I running script and received the error at ldap_type not exist Global variable. I changed by adding "self" on front variable.

Traceback (most recent call last):
  File "change_config.py", line 48, in <module>
    r = name_changer.startup()
  File "/root/change_gluu_host.py", line 162, in startup
    if ldap_type == 'openldap':
NameError: global name 'ldap_type' is not defined