### PR TITLE
oxAuth #1063

### DIFF
--- a/templates/oxauth-config.json
+++ b/templates/oxauth-config.json
@@ -242,6 +242,7 @@
     "pairwiseIdType":"algorithmic",
     "pairwiseCalculationKey":"%(pairwiseCalculationKey)s",
     "pairwiseCalculationSalt": "%(pairwiseCalculationSalt)s",
+    "shareSubjectIdBetweenClientsWithSameSectorId": true,
     "webKeysStorage": "keystore",
     "dnName": "%(default_openid_jks_dn_name)s",
     "keyStoreFile": "%(oxauth_openid_jks_fn)s",


### PR DESCRIPTION
Add a config value to allow to share the same sub between two Clients with the same sector identifier
https://github.com/GluuFederation/oxAuth/issues/1063