### PR TITLE
passport conf env updates

### DIFF
--- a/templates/node/passport
+++ b/templates/node/passport
@@ -1,10 +1,11 @@
 NODE_HOME=%(node_home)s
 NODE=$NODE_HOME/bin/node
 
-NODE_BASE=%(node_base)s/passport/server
+NODE_BASE=%(node_base)s/passport
 NODE_LOGS=${NODE_BASE}/logs
-NODE_APP=app.js
-NODE_OPTIONS="PORT=8090 NODE_ENV=production NODE_CONFIG_DIR=$NODE_BASE HOSTNAME=localhost"
+NODE_CONFIG_DIR=${NODE_BASE}/config
+NODE_APP=server/app.js
+NODE_OPTIONS="PORT=8090 NODE_ENV=production HOSTNAME=localhost"
 NODE_ARGS="--max-old-space-size=%(passport_max_mem)s"
 APP_ARGS=""
 


### PR DESCRIPTION
Adjusting passport env for new config.

- `NODE_BASE` changed to  `/passport`. (`/passport/server` would be something like saying that `src` is home.)
- `NODE_CONFIG_DIR = ${NODE_BASE}/config` , config files are in `/config`
- `NODE_APP=server/app.js` - here the suggested approach would be running `npm start` and not using `node server/app.js`, but this would envolve editing passport shell script and I'm not familiar with it, gonna raise issue.
- removed `NODE_CONFIG_DIR=$NODE_BASE` from `NODE_OPTIONS` because config dir is now setted on env.