### PR TITLE
Create logs-zipper.py

### DIFF
--- a/static/scripts/logs-zipper.py
+++ b/static/scripts/logs-zipper.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python
+
+import os
+import sys
+import zipfile
+
+root_path = ''
+version_info = ''
+directory_list = {'oxauth': '/opt/gluu/jetty/oxauth/logs/',
+                  'identity': '/opt/gluu/jetty/identity/logs/',
+                  'idp': '/opt/gluu/jetty/idp/logs/',
+                  'setup': '/install/community-edition-setup/',
+                  'shibboleth': '/opt/shibboleth-idp/logs/',
+                  'oxauth-rp': '/opt/gluu/jetty/oxauth-rp/logs/',
+                  'redis': '/opt/gluu/node/passport/node_modules/redis-parser/',
+                  'apache': '/var/log/apache2/',
+                  'passport': '/opt/gluu/node/passport/logs'}
+
+# to check file is running from out side of gluu-server
+if os.path.exists('/opt/gluu/jetty/oxauth'):
+    version_info = os.popen('/opt/gluu/bin/show_version.py').read()
+else:
+    root_path = '/opt/gluu-server'
+    version_info = os.popen('/sbin/gluu-serverd version').read()
+
+if version_info == '':
+    sys.exit('Run this program as a root user')
+
+handle = zipfile.ZipFile('All_logs.zip', 'w')
+
+for directory_name in directory_list:
+    path = root_path + directory_list[directory_name]
+    if os.path.exists(path):
+        os.chdir(path)
+        for file in os.listdir():
+            if file.endswith('.log'):
+                handle.write(file,
+                             os.path.relpath(os.path.join(directory_name, file), path),
+                             compress_type=zipfile.ZIP_DEFLATED)
+
+handle.writestr('version_info.txt', version_info)
+handle.close()


### PR DESCRIPTION
Following procedure to run this script:
1. login to gluu-server
2. run -> wget [URL]
3. run -> python3 logs-zipper.py
This will generate the 'All_logs.zip' file.

This script can be run also from outside of gluu-server.

![Screenshot from 2020-11-25 18-26-15](https://user-images.githubusercontent.com/20867846/100775693-cd737280-342d-11eb-8b36-6750b77b4298.png)
![Screenshot from 2020-11-25 18-30-55](https://user-images.githubusercontent.com/20867846/100775686-cc424580-342d-11eb-9bf5-5e222104deb6.png)
![Screenshot from 2020-11-25 18-31-06](https://user-images.githubusercontent.com/20867846/100775682-cba9af00-342d-11eb-8a46-05f48a32b4a3.png)
![Screenshot from 2020-11-25 18-31-21](https://user-images.githubusercontent.com/20867846/100775675-c9dfeb80-342d-11eb-82fe-9a8f4d0e1ddf.png)