### PR TITLE
fix: sql57 connection with java 11.0.11

### DIFF
--- a/templates/gluu-sql.properties
+++ b/templates/gluu-sql.properties
@@ -1,6 +1,6 @@
 db.schema.name=%(rdbm_db)s
 
-connection.uri=jdbc:%(rdbm_type)s://%(rdbm_host)s:%(rdbm_port)s/%(rdbm_db)s
+connection.uri=jdbc:%(rdbm_type)s://%(rdbm_host)s:%(rdbm_port)s/%(rdbm_db)s?enabledTLSProtocols=TLSv1.2
 
 connection.driver-property.serverTimezone=%(server_time_zone)s
 # Prefix connection.driver-property.key=value will be coverterd to key=value JDBC driver properties


### PR DESCRIPTION
Hey,

During one of our setups and tests with  MySql 5.7 we got several errors back from all services. 
`javax.net.ssl.SSLHandshakeException: No appropriate protocol (protocol is disabled or cipher suites are inappropriate)
` 
This was due to the fact we also upgraded java to `v11.0.11` and older TLS versions (below TLSv1.2) were not supported.  By sql docs a connection property has to be added called `enabledTLSProtocols` to the JDBC. 

fix:

to the sql properties file the connection parameter should look like : 

```
connection.uri=jdbc:%(rdbm_type)s://%(rdbm_host)s:%(rdbm_port)s/%(rdbm_db)s?enabledTLSProtocols=TLSv1.2
```

Please keep an eye out  as mysql 5.7 will not function with CE if the param is not added with java 11.0.11.

Adding this option did not affect installation with other mysql versions and java 11.0.9.