### PR TITLE
fix: cacert path in oxtrust config (ref: #874)

### DIFF
--- a/templates/oxtrust/oxtrust-config.json
+++ b/templates/oxtrust/oxtrust-config.json
@@ -67,8 +67,8 @@
 
     "ldifStore":"/var/gluu/identity/removed",
 
-    "caCertsLocation":"/usr/java/latest/jre/lib/security/cacerts",
-    "caCertsPassphrase":"",
+    "caCertsLocation":"%(default_trust_store_fn)s",
+    "caCertsPassphrase":"%(defaultTrustStorePW)s",
 
     "certDir":"/etc/certs/",
     "tempCertDir":"/etc/certs/temp",


### PR DESCRIPTION
As described in https://github.com/GluuFederation/community-edition-setup/issues/874