### PR TITLE
fix: remove apache config when uninstall 

### DIFF
--- a/gluu_install.py
+++ b/gluu_install.py
@@ -240,6 +240,20 @@ if argsp.uninstall:
         print("Executing", cmd)
         os.system('rm -r -f ' + p)
 
+    apache_conf_fn_list = []
+
+    if shutil.which('zypper'):
+        apache_conf_fn_list = ['/etc/apache2/vhosts.d/_https_gluu.conf']
+    elif shutil.which('yum') or shutil.which('dnf'):
+        apache_conf_fn_list = ['/etc/httpd/conf.d/https_gluu.conf']
+    elif shutil.which('apt'):
+        apache_conf_fn_list = ['/etc/apache2/sites-enabled/https_gluu.conf', '/etc/apache2/sites-available/https_gluu.conf']
+
+    for fn in apache_conf_fn_list:
+        if os.path.exists(fn):
+            print("Removing", fn)
+            os.unlink(fn)
+
     sys.exit()
 
 def download(url, target_fn):


### PR DESCRIPTION
Remove apache config files when uninstall as described in https://github.com/GluuFederation/community-edition-setup/issues/892