### PR TITLE
fix: column type of oxDocument.document is TEXT

### DIFF
--- a/static/rdbm/sql_data_types.json
+++ b/static/rdbm/sql_data_types.json
@@ -882,5 +882,13 @@
     "spanner": {
       "type": "ARRAY<STRING(MAX)>"
     }
+  },
+  "document": {
+    "mysql": {
+      "type": "TEXT"
+    },
+    "pgsql": {
+      "type": "TEXT"
+    }
   }
 }


### PR DESCRIPTION
closes #930

After this fix:

```
mysql>  show columns in oxDocument where Field = 'document';
+----------+------+------+-----+---------+-------+
| Field    | Type | Null | Key | Default | Extra |
+----------+------+------+-----+---------+-------+
| document | text | YES  |     | NULL    |       |
+----------+------+------+-----+---------+-------+
1 row in set (0.01 sec)
```