### PR TITLE
fix: cb spanner libraries separated fixes

### DIFF
--- a/setup_app/installers/couchbase.py
+++ b/setup_app/installers/couchbase.py
@@ -394,7 +394,7 @@ class CouchbaseInstaller(PackageUtils, BaseInstaller):
         if not os.path.exists(self.common_lib_dir):
             self.createDirs(self.common_lib_dir)
         shutil.unpack_archive(lib_archive, self.common_lib_dir)
-        self.chown(self.common_lib_dir = os.path.join(Config.jetty_base, 'common'), Config.jetty_user, Config.gluu_group, True)
+        self.chown(os.path.join(Config.jetty_base, 'common'), Config.jetty_user, Config.gluu_group, True)
 
     def installed(self):
 

--- a/setup_app/installers/couchbase.py
+++ b/setup_app/installers/couchbase.py
@@ -394,6 +394,7 @@ class CouchbaseInstaller(PackageUtils, BaseInstaller):
         if not os.path.exists(self.common_lib_dir):
             self.createDirs(self.common_lib_dir)
         shutil.unpack_archive(lib_archive, self.common_lib_dir)
+        self.chown(self.common_lib_dir = os.path.join(Config.jetty_base, 'common'), Config.jetty_user, Config.gluu_group, True)
 
     def installed(self):
 

--- a/setup_app/installers/jetty.py
+++ b/setup_app/installers/jetty.py
@@ -193,7 +193,7 @@ class JettyInstaller(BaseInstaller, SetupUtils):
         self.copyFile(jettyServiceConfiguration, Config.osDefault)
         self.run([paths.cmd_chown, '{}:{}'.format(Config.templateRenderingDict['service_user'], Config.gluu_group), os.path.join(Config.osDefault, serviceName)])
 
-        # Render web eources file
+        # Render web reources file
         try:
             web_resources = '%s_web_resources.xml' % serviceName
             if os.path.exists('%s/jetty/%s' % (Config.templateFolder, web_resources)):
@@ -204,10 +204,15 @@ class JettyInstaller(BaseInstaller, SetupUtils):
 
         # Render web context file
         try:
-            web_context = '%s.xml' % serviceName
-            if os.path.exists('%s/jetty/%s' % (Config.templateFolder, web_context)):
-                self.renderTemplateInOut(web_context, '%s/jetty' % Config.templateFolder, '%s/jetty' % Config.outputFolder)
-                self.copyFile('%s/jetty/%s' % (Config.outputFolder, web_context), "%s/%s/webapps" % (self.jetty_base, serviceName))
+            web_context = '{}.xml'.format(serviceName)
+            jetty_temp_dir = os.path.join(Config.templateFolder, 'jetty')
+            if not os.path.exists(os.path.join(jetty_temp_dir, web_context)):
+                web_context = 'default_webcontext.xml'
+            self.renderTemplateInOut(
+                    web_context,
+                    jetty_temp_dir,
+                    out_file=os.path.join(self.jetty_base, serviceName, 'webapps/{}.xml'.format(serviceName))
+                )
         except:
             self.logIt("Error rendering service '%s' context xml" % serviceName, True)
 

--- a/setup_app/installers/rdbm.py
+++ b/setup_app/installers/rdbm.py
@@ -426,7 +426,7 @@ class RDBMInstaller(BaseInstaller, SetupUtils):
         if not os.path.exists(self.common_lib_dir):
             self.createDirs(self.common_lib_dir)
         shutil.unpack_archive(lib_archive, self.common_lib_dir)
-        self.chown(self.common_lib_dir = os.path.join(Config.jetty_base, 'common'), Config.jetty_user, Config.gluu_group, True)
+        self.chown(os.path.join(Config.jetty_base, 'common'), Config.jetty_user, Config.gluu_group, True)
 
     def create_folders(self):
         self.createDirs(Config.static_rdbm_dir)

--- a/setup_app/installers/rdbm.py
+++ b/setup_app/installers/rdbm.py
@@ -426,6 +426,7 @@ class RDBMInstaller(BaseInstaller, SetupUtils):
         if not os.path.exists(self.common_lib_dir):
             self.createDirs(self.common_lib_dir)
         shutil.unpack_archive(lib_archive, self.common_lib_dir)
+        self.chown(self.common_lib_dir = os.path.join(Config.jetty_base, 'common'), Config.jetty_user, Config.gluu_group, True)
 
     def create_folders(self):
         self.createDirs(Config.static_rdbm_dir)

--- a/setup_app/utils/setup_utils.py
+++ b/setup_app/utils/setup_utils.py
@@ -404,10 +404,13 @@ class SetupUtils(Crypto64):
 
         return rendered_text
 
-    def renderTemplateInOut(self, file_path, template_folder, output_folder, backup=False):
+    def renderTemplateInOut(self, file_path, template_folder, output_folder=None, backup=False, out_file=None):
         fn = os.path.basename(file_path)
         in_fp = os.path.join(template_folder, fn) 
         self.logIt("Rendering template %s" % in_fp)
+
+        if not output_folder:
+            output_folder = os.path.dirname(out_file)
 
         # Create output folder if needed
         if not os.path.exists(output_folder):
@@ -415,7 +418,7 @@ class SetupUtils(Crypto64):
 
         rendered_text = self.render_template(in_fp)
 
-        out_fp = os.path.join(output_folder, fn)
+        out_fp = out_file or os.path.join(output_folder, fn)
         self.writeFile(out_fp, rendered_text, backup=backup)
 
     def renderTemplate(self, filePath):

--- a/templates/jetty/default_webcontext.xml
+++ b/templates/jetty/default_webcontext.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"  encoding="ISO-8859-1"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_0.dtd">
+
+<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+    <Set name="contextPath">/%(service_name)s</Set>
+    <Set name="war">
+        <Property name="jetty.webapps" default="." />/%(service_name)s.war
+    </Set>
+    <Set name="extractWAR">true</Set>
+
+    <!-- <Set name="extraClasspath"></Set> -->
+</Configure>


### PR DESCRIPTION
Fixes issue for #937

1) chown jetty:gluu /opt/gluu/jetty/common
2) Add `default_webcontext.xml` to use if there is no webcontext file for service