### PR TITLE
fix: spanner data type for document

### DIFF
--- a/static/rdbm/sql_data_types.json
+++ b/static/rdbm/sql_data_types.json
@@ -889,6 +889,9 @@
     },
     "pgsql": {
       "type": "TEXT"
+    },
+    "spanner": {
+      "type": "STRING(MAX)"
     }
   }
 }


### PR DESCRIPTION
Spanner data type for attribute **document** was missing