### PR TITLE
fix: disable IDP in post form installation for spanner db

### DIFF
--- a/setup_app/utils/tui.py
+++ b/setup_app/utils/tui.py
@@ -313,6 +313,9 @@ class ServicesForm(GluuSetupForm):
                     self.services_before_this_form.append(service)
                 cb.update()
 
+        if Config.installed_instance and Config.rdbm_type == 'spanner':
+            self.installSaml.editable = False
+
         if Config.installed_instance and 'installCasa' in self.services_before_this_form:
             self.oxd_url.hidden = True
             self.oxd_url.update()


### PR DESCRIPTION
When DB is Spanner, we should not offer installing IDP for post-setup