### PR TITLE
fix: fixing of the bug: opendj + pkcs11;

### DIFF
--- a/setup_app/installers/opendj.py
+++ b/setup_app/installers/opendj.py
@@ -194,6 +194,7 @@ class OpenDjInstaller(BaseInstaller, SetupUtils):
     def generate_opendj_certs(self):
 
         self.writeFile(self.opendj_trusstore_setup_key_fn, Config.opendj_truststore_pass)
+        self.writeFile(self.opendj_pck11_setup_key_fn, Config.defaultTrustStorePW)
 
         keystore = Config.opendj_trust_store_fn if Config.opendj_truststore_format.upper() == 'BCFKS' else 'NONE'
 


### PR DESCRIPTION
This fix has been developed by follow reason:
- if we use follow install options:  **-profile=DISA-STIG** and **-opendj-keystore-type=pkcs11**, follow property file is generated: **opendj-setup.properties.pkcs11**:
```
...
keyStorePasswordFile            =/root/.keystore.pin
...
```
Db **sql:/etc/pki/nssdb**, that is used for saving **pkcs11** certificates, doesn't need a password, so we don't create: **/root/.keystore.pin**. In this case opendj setup is down.
This issue can be resolved, creating file **/root/.keystore.pin**, that contains some random text.
