### PR TITLE
Change response status 200 (Ok) by 201 (Created) for Client Registration

### DIFF
--- a/templates/oxauth/oxauth-config.json
+++ b/templates/oxauth/oxauth-config.json
@@ -371,5 +371,6 @@
     },
     "deviceAuthzRequestExpiresIn": 1800,
     "deviceAuthzTokenPollInterval": 5,
-    "deviceAuthzResponseTypeToProcessAuthz": "code"
+    "deviceAuthzResponseTypeToProcessAuthz": "code",
+    "return200OnClientRegistration": true
 }


### PR DESCRIPTION
Added new configuration `return200OnClientRegistration` with default value in `true`

https://github.com/GluuFederation/oxAuth/issues/1780