### PR TITLE
fix: remove oxClaimRedirectURI from sql_data_types.json to make it JSON

### DIFF
--- a/static/rdbm/sql_data_types.json
+++ b/static/rdbm/sql_data_types.json
@@ -312,17 +312,6 @@
       "type": "STRING(MAX)"
     }
   },
-  "oxClaimRedirectURI": {
-    "mysql": {
-      "type": "TINYTEXT"
-    },
-    "pgsql": {
-      "type": "TEXT"
-    },
-    "spanner": {
-      "type": "STRING(MAX)"
-    }
-  },
   "oxJwt": {
     "mysql": {
       "type": "TEXT"


### PR DESCRIPTION
This PR is related to https://github.com/GluuFederation/oxTrust/issues/2341

All multivalued attributes are JSON if not explicitly defined in `static/rdbm/sql_data_types.json`, We have to remove `oxClaimRedirectURI` form `sql_data_types.json`

